### PR TITLE
Update Mesh, Shader, and Material structs to 3.0.0

### DIFF
--- a/src/bindbc/raylib/types.d
+++ b/src/bindbc/raylib/types.d
@@ -227,13 +227,23 @@ struct Mesh {
 
    // OpenGL identifiers
    uint vaoId; // OpenGL Vertex Array Object id
-   uint[7] vboId; // OpenGL Vertex Buffer Objects id (default vertex data)
+
+   static if (raylibSupport >= RaylibSupport.raylib300) {
+      uint* vboId; // OpenGL Vertex Buffer Objects id (default vertex data)
+   } else {
+      uint[7] vboId; // OpenGL Vertex Buffer Objects id (default vertex data)
+   }
 }
 
 // Shader type (generic)
 struct Shader {
    uint id; // Shader program id
-   int[MAX_SHADER_LOCATIONS] locs; // Shader locations array
+
+   static if (raylibSupport >= RaylibSupport.raylib300) {
+      int* locs; // Shader locations array
+   } else {
+      int[MAX_SHADER_LOCATIONS] locs; // Shader locations array
+   }
 }
 
 // Material texture map
@@ -246,7 +256,13 @@ struct MaterialMap {
 // Material type (generic)
 struct Material {
    Shader shader; // Material shader
-   MaterialMap[MAX_MATERIAL_MAPS] maps; // Material maps
+
+   static if (raylibSupport >= RaylibSupport.raylib300) {
+      MaterialMap* maps; // Material maps
+   } else {
+      MaterialMap[MAX_MATERIAL_MAPS] maps; // Material maps
+   }
+
    float* params; // Material generic parameters (if required)
 }
 


### PR DESCRIPTION
In version 3.0.0 of raylib (specifically raysan5/raylib@3d5fa81bf2753badacf9e8c01c51943a0c3acf85) certain structs started using dynamic arrays instead of static arrays.